### PR TITLE
Change example to call class instead of module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ urx was primarily developed by [Olivier Roulet-Dubonnet](https://github.com/orou
 ```python
 import urx
 
-rob = urx.robot("192.168.0.100")
+rob = urx.Robot("192.168.0.100")
 rob.set_tcp((0, 0, 0.1, 0, 0, 0))
 rob.set_payload(2, (0, 0, 0.1))
 rob.movej((1, 2, 3, 4, 5, 6), a, v) 


### PR DESCRIPTION
`urx.robot` is a module and thus not callable. I think the `Robot` class is what's meant here.