### PR TITLE
3.x firmware compatible, speedx, set_analog_out and new_csys_from_xpy

### DIFF
--- a/urx/robot.py
+++ b/urx/robot.py
@@ -149,9 +149,13 @@ class Robot(URRobot):
         send command to robot formated like speedl or speedj
         move at given velocities until minimum min_time seconds
         """
-        v = self.csys.orient * m3d.Vector(velocities[:3])
-        w = self.csys.orient * m3d.Vector(velocities[3:])
-        URRobot.speedx(self, command, np.concatenate((v.array, w.array)), acc, min_time)
+        if command != "speedj":
+            v = self.csys.orient * m3d.Vector(velocities[:3])
+            w = self.csys.orient * m3d.Vector(velocities[3:])
+            vels = np.concatenate((v.array, w.array))
+        else:
+            vels = velocities
+        URRobot.speedx(self, command, vels, acc, min_time)
 
     def speedl_tool(self, velocities, acc, min_time):
         """

--- a/urx/robot.py
+++ b/urx/robot.py
@@ -217,7 +217,8 @@ class Robot(URRobot):
 
     def new_csys_from_xpy(self):
         """
-        Return new coordinate system from three points: X, Origin, Y
+        Restores and returns new coordinate system calculated from three points: X, Origin, Y
+
         based on math3d: Transform.new_from_xyp
         """
         # Set coord. sys. to 0
@@ -239,7 +240,11 @@ class Robot(URRobot):
         pose = URRobot.getl(self)
         print("Introduced point defining Y: {}".format(pose[:3]))
         py = m3d.Vector(pose[:3])
-        return m3d.Transform.new_from_xyp(px - p0, py - p0, p0)
+
+        new_csys = m3d.Transform.new_from_xyp(px - p0, py - p0, p0)
+        self.set_csys(new_csys)
+
+        return new_csys
 
     @property
     def x(self):

--- a/urx/robot.py
+++ b/urx/robot.py
@@ -214,20 +214,26 @@ class Robot(URRobot):
         Return new coordinate system from three points: X, Origin, Y
         based on math3d: Transform.new_from_xyp
         """
+        # Set coord. sys. to 0
+        self.csys = m3d.Transform()
+
         print("A new coordinate system will be defined from the next three points")
         print("Firs point is X, second Origin, third Y")
         print("Set it as a new reference by calling myrobot.set_csys(new_csys)")
         input("Move to first point and click Enter")
         # we do not use get_pose so we avoid rounding values
         pose = URRobot.getl(self)
+        print("Introduced point defining X: {}".format(pose[:3]))
+        px = m3d.Vector(pose[:3])
+        input("Move to second point and click Enter")
+        pose = URRobot.getl(self)
+        print("Introduced point defining Origo: {}".format(pose[:3]))
         p0 = m3d.Vector(pose[:3])
-        input("Move to second point and click Enter")
+        input("Move to third point and click Enter")
         pose = URRobot.getl(self)
-        p1 = m3d.Vector(pose[:3])
-        input("Move to second point and click Enter")
-        pose = URRobot.getl(self)
-        p2 = m3d.Vector(pose[:3])
-        return m3d.Transform.new_from_xyp(p0 - p1, p2 - p1, p1)
+        print("Introduced point defining Y: {}".format(pose[:3]))
+        py = m3d.Vector(pose[:3])
+        return m3d.Transform.new_from_xyp(px - p0, py - p0, p0)
 
     @property
     def x(self):

--- a/urx/robot.py
+++ b/urx/robot.py
@@ -144,18 +144,20 @@ class Robot(URRobot):
         trans = self.get_pose(wait)
         return trans.pos
 
-    def speedx(self, command, velocities, acc, min_time):
+    def speedl(self, velocities, acc, min_time):
         """
-        send command to robot formated like speedl or speedj
         move at given velocities until minimum min_time seconds
         """
-        if command != "speedj":
-            v = self.csys.orient * m3d.Vector(velocities[:3])
-            w = self.csys.orient * m3d.Vector(velocities[3:])
-            vels = np.concatenate((v.array, w.array))
-        else:
-            vels = velocities
-        URRobot.speedx(self, command, vels, acc, min_time)
+        v = self.csys.orient * m3d.Vector(velocities[:3])
+        w = self.csys.orient * m3d.Vector(velocities[3:])
+        vels = np.concatenate((v.array, w.array))
+        return self.speedx("speedl", vels, acc, min_time)
+
+    def speedj(self, velocities, acc, min_time):
+        """
+        move at given joint velocities until minimum min_time seconds
+        """
+        return self.speedx("speedj", velocities, acc, min_time)
 
     def speedl_tool(self, velocities, acc, min_time):
         """

--- a/urx/robot.py
+++ b/urx/robot.py
@@ -227,7 +227,7 @@ class Robot(URRobot):
         input("Move to second point and click Enter")
         pose = URRobot.getl(self)
         p2 = m3d.Vector(pose[:3])
-        return m3d.Transform.new_from_xyp(p1 - p0, p2 - p0, p0)
+        return m3d.Transform.new_from_xyp(p0 - p1, p2 - p1, p1)
 
     @property
     def x(self):

--- a/urx/urrobot.py
+++ b/urx/urrobot.py
@@ -258,18 +258,6 @@ class URRobot(object):
         prog = "{}([{},{},{},{},{},{}], a={}, t_min={})".format(command, *vels)
         self.send_program(prog)
 
-    def speedl(self, velocities, acc, min_time):
-        """
-        move at given velocities until minimum min_time seconds
-        """
-        return self.speedx("speedl", velocities, acc, min_time)
-
-    def speedj(self, velocities, acc, min_time):
-        """
-        move at given joint velocities until minimum min_time seconds
-        """
-        return self.speedx("speedj", velocities, acc, min_time)
-
     def movej(self, joints, acc=0.1, vel=0.05, wait=True, relative=False, threshold=None):
         """
         move in joint space

--- a/urx/urrobot.py
+++ b/urx/urrobot.py
@@ -181,7 +181,7 @@ class URRobot(object):
         """
         set analog output, val is a float
         """
-        prog = "set_analog_output(%s, %s)" % (output, val)
+        prog = "set_analog_out(%s, %s)" % (output, val)
         self.send_program(prog)
 
     def set_tool_voltage(self, val):

--- a/urx/ursecmon.py
+++ b/urx/ursecmon.py
@@ -88,7 +88,9 @@ class ParserUtils(object):
             elif ptype == 5:
                 allData["LaserPointer(OBSOLETE)"] = self._get_data(pdata, "iBddd", ("size", "type"))
             elif ptype == 3:
-                allData["MasterBoardData"] = self._get_data(pdata, "iBhhbbddbbddffffBBb", ("size", "type", "digitalInputBits", "digitalOutputBits", "analogInputRange0", "analogInputRange1", "analogInput0", "analogInput1", "analogInputDomain0", "analogInputDomain1", "analogOutput0", "analogOutput1", "masterBoardTemperature", "robotVoltage48V", "robotCurrent", "masterIOCurrent"))  # , "masterSafetyState" ,"masterOnOffState", "euromap67InterfaceInstalled"   ))
+                #fmt = "iBhhbbddbbddffffBBb"    # firmware 1.6, 1.7, 1.8
+                fmt = "iBiibbddbbddffffBBb"     # firmware 3.0, 3.1, 3.2
+                allData["MasterBoardData"] = self._get_data(pdata, fmt, ("size", "type", "digitalInputBits", "digitalOutputBits", "analogInputRange0", "analogInputRange1", "analogInput0", "analogInput1", "analogInputDomain0", "analogInputDomain1", "analogOutput0", "analogOutput1", "masterBoardTemperature", "robotVoltage48V", "robotCurrent", "masterIOCurrent"))  # , "masterSafetyState" ,"masterOnOffState", "euromap67InterfaceInstalled"   )) 
             elif ptype == 2:
                 allData["ToolData"] = self._get_data(pdata, "iBbbddfBffB", ("size", "type", "analoginputRange2", "analoginputRange3", "analogInput2", "analogInput3", "toolVoltage48V", "toolOutputVoltage", "toolCurrent", "toolTemperature", "toolMode"))
             elif ptype == 9:

--- a/urx/ursecmon.py
+++ b/urx/ursecmon.py
@@ -88,8 +88,12 @@ class ParserUtils(object):
             elif ptype == 5:
                 allData["LaserPointer(OBSOLETE)"] = self._get_data(pdata, "iBddd", ("size", "type"))
             elif ptype == 3:
-                #fmt = "iBhhbbddbbddffffBBb"    # firmware 1.6, 1.7, 1.8
-                fmt = "iBiibbddbbddffffBBb"     # firmware 3.0, 3.1, 3.2
+
+                if self.version >= (3, 0):
+                    fmt = "iBiibbddbbddffffBBb"     # firmware >= 3.0
+                else:
+                    fmt = "iBhhbbddbbddffffBBb"     # firmware < 3.0
+
                 allData["MasterBoardData"] = self._get_data(pdata, fmt, ("size", "type", "digitalInputBits", "digitalOutputBits", "analogInputRange0", "analogInputRange1", "analogInput0", "analogInput1", "analogInputDomain0", "analogInputDomain1", "analogOutput0", "analogOutput1", "masterBoardTemperature", "robotVoltage48V", "robotCurrent", "masterIOCurrent"))  # , "masterSafetyState" ,"masterOnOffState", "euromap67InterfaceInstalled"   )) 
             elif ptype == 2:
                 allData["ToolData"] = self._get_data(pdata, "iBbbddfBffB", ("size", "type", "analoginputRange2", "analoginputRange3", "analogInput2", "analogInput3", "toolVoltage48V", "toolOutputVoltage", "toolCurrent", "toolTemperature", "toolMode"))


### PR DESCRIPTION
- ursecmon.py: Parses packages from 3.x firmware. Still could be improved for making urx able to handle all firmwares.
- speedx in robot.py: avoid orienting speed when only joint movement is desired (speedj)
- set_analog_out: send correct URScript program
- new_csys_from_xpy: fine tuned