### PR TITLE
Sleep the gripper on activation to avoid usb conflicts

### DIFF
--- a/urx/robotiq_two_finger_gripper.py
+++ b/urx/robotiq_two_finger_gripper.py
@@ -183,6 +183,9 @@ class Robotiq_Two_Finger_Gripper(object):
         urscript._set_robot_activate()
         urscript._set_gripper_activate()
 
+        # Wait on activation to avoid USB conflicts
+        urscript._sleep(0.1)
+
         return urscript
 
     def gripper_action(self, value):


### PR DESCRIPTION
@oroulet - We discovered that customers with the Robotiq Camera could no longer use the Robotiq Gripper with this script.  From Robotiq Support:

> I've tested your script in our robot equipped with a gripper and a camera and it does exactly the same as your customer, nothing happen!!!  I've simply added a sleep time after GTO command and now it works.  I think the setup combining gripper and camera on the same USB cause this.  I'll inform the R&D about this.

The new program will look like this when run:

```
def myProg(): 
socket_close("gripper_socket") 
socket_open("127.0.0.1",63352,"gripper_socket") 
set_analog_inputrange(0,0) 
set_analog_inputrange(1,0) 
set_analog_inputrange(2,0) 
set_analog_inputrange(3,0) 
set_analog_outputdomain(0,0) 
set_analog_outputdomain(1,0) 
set_tool_voltage(0) 
set_runstate_outputs([]) 
set_payload(0.95) 
socket_set_var("SPE",255,"gripper_socket") 
sync() 
socket_set_var("FOR",50,"gripper_socket") 
sync() 
socket_set_var("ACT",1,"gripper_socket") 
sync() 
socket_set_var("GTO",1,"gripper_socket") 
sync() 
sleep(0.1)​
socket_set_var("POS",255,"gripper_socket") 
sync() 
sleep(2) 
end 
myProg()
```