### PR TITLE
Change how freedrive is instantiated. Add freedrive timeout with default

### DIFF
--- a/urx/urrobot.py
+++ b/urx/urrobot.py
@@ -387,13 +387,15 @@ class URRobot(object):
         if self.rtmon:
             self.rtmon.stop()
 
-    def set_freedrive(self, val):
+    def set_freedrive(self, val, timeout=60):
         """
-        set robot in freedrive/brackdrive mode where an operator can jogg
-        the robot to wished pose
+        set robot in freedrive/backdrive mode where an operator can jog
+        the robot to wished pose.
+
+        Freedrive will timeout at 60 seconds.
         """
         if val:
-            self.send_program("set robotmode freedrive")
+            self.send_program("def myProg():\n\tfreedrive_mode()\n\tsleep({})\nend".format(timeout))
         else:
             self.send_program("set robotmode run")
 


### PR DESCRIPTION
Fixes #11 

@oroulet - This has been a long time coming so apologies.  Here is how we do freedrive at Tend.  The problem we faced is that the program ends as soon as it begins.  By adding a timeout (here it is 60 seconds but we use 3600 seconds internally) the program will remain running.  Hopefully others will find this useful.